### PR TITLE
Fix reference to electrum-ltc.png

### DIFF
--- a/icons.qrc
+++ b/icons.qrc
@@ -1,6 +1,6 @@
 <RCC>
   <qresource prefix="/" >
-    <file>icons/electrum-ltc.png</file>
+    <file>icons/electrum-vtc.png</file>
     <file>icons/clock1.png</file>
     <file>icons/clock2.png</file>
     <file>icons/clock3.png</file>


### PR DESCRIPTION
pyrcc4 icons.qrc -o gui/qt/icons_rc.py
Cannot find file: icons/electrum-ltc.png