### PR TITLE
update readme creating binaries section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,13 +16,5 @@ env/
 .tox/
 .buildozer/
 bin/
-contrib/dns/
-contrib/ecdsa/
-contrib/jsonrpclib/
-contrib/pyaes/
-contrib/qrcode/
-contrib/socks.py
-contrib/sockshandler.py
-contrib/pbkdf2.py
 contrib/build-wine/tmp/
 .vscode/settings.json

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,8 @@ To create binaries, create the 'packages' directory::
 
 This directory contains the python dependencies used by Electrum.
 If you get ImportErrors, this is because the modules aren't installed or
-are installed compressed. unzipping the modules to the contrib folder should
-fix the errors (refer to the contrib/* lines in .gitignore)
+are installed, but compressed. Uninstall/install dependencies with pip,
+which always installs everything unzipped.
 
 Mac OS X
 --------


### PR DESCRIPTION
Turns out `python setup.py install` installs packages zipped. However, `pip` installs them unzipped. The make_packages script requires unzipped packages, so this is clearer in the readme now.