### PR TITLE
Add Coinomi Electrum nodes

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -54,6 +54,8 @@ DEFAULT_SERVERS = {
     'fr1.vtconline.org': DEFAULT_PORTS,
     'uk1.vtconline.org': DEFAULT_PORTS,
     'vtc.horriblecoders.com': DEFAULT_PORTS,
+    'vtc-cce-1.coinomi.net': {'t':'5028'},
+    'vtc-cce-2.coinomi.net': {'t':'5028'},
 }
 
 '''


### PR DESCRIPTION
They aren't SSL so they won't be used by default.

However if the user opts out of SSL then they will be used.