### PR TITLE
Trezor support and misc fixes.

### DIFF
--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -123,16 +123,16 @@ class BaseWizard(object):
                 ('restore_from_seed', _('I already have a seed')),
                 ('restore_from_key', _('Use public or private keys')),
             ]
-            #if not self.is_kivy:
-            #    choices.append(('choose_hw_device',  _('Use a hardware device')))
+            if not self.is_kivy:
+                choices.append(('choose_hw_device',  _('Use a hardware device')))
         else:
             message = _('Add a cosigner to your multi-sig wallet')
             choices = [
                 ('restore_from_key', _('Enter cosigner key')),
                 ('restore_from_seed', _('Enter cosigner seed')),
             ]
-            #if not self.is_kivy:
-            #    choices.append(('choose_hw_device',  _('Cosign with hardware device')))
+            if not self.is_kivy:
+                choices.append(('choose_hw_device',  _('Cosign with hardware device')))
 
         self.choice_dialog(title=title, message=message, choices=choices, run_next=self.run)
 

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -494,7 +494,7 @@ from ecdsa.util import string_to_number, number_to_string
 def msg_magic(message):
     varint = var_int(len(message))
     encoded_varint = "".join([chr(int(varint[i:i+2], 16)) for i in xrange(0, len(varint), 2)])
-    return "\x19Litecoin Signed Message:\n" + encoded_varint + message
+    return "\x19Vertcoin Signed Message:\n" + encoded_varint + message
 
 
 def verify_message(address, sig, message):

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -681,7 +681,7 @@ def bip44_derivation(account_id):
     if bitcoin.TESTNET:
         return "m/44'/1'/%d'"% int(account_id)
     else:
-        return "m/44'/2'/%d'"% int(account_id)
+        return "m/44'/28'/%d'"% int(account_id)
 
 def from_seed(seed, passphrase):
     t = seed_type(seed)

--- a/plugins/trezor/clientbase.py
+++ b/plugins/trezor/clientbase.py
@@ -208,6 +208,13 @@ class TrezorClientBase(GuiMixin, PrintError):
         f = self.features
         return (f.major_version, f.minor_version, f.patch_version)
 
+    def supports_coin(self, coin_name):
+        f = self.features
+        for coin in f.coins:
+            if coin.coin_name == coin_name:
+                return True
+        return False
+
     def atleast_version(self, major, minor=0, patch=0):
         return cmp(self.firmware_version(), (major, minor, patch)) >= 0
 

--- a/plugins/trezor/plugin.py
+++ b/plugins/trezor/plugin.py
@@ -124,6 +124,13 @@ class TrezorCompatiblePlugin(HW_PluginBase):
             self.print_error("ping failed", str(e))
             return None
 
+        if not client.supports_coin("Vertcoin"):
+            msg = (_('This TREZOR does not support Vertcoin. '
+                     'Please update the firmware.'))
+            self.print_error(msg)
+            handler.show_error(msg)
+            return None
+
         if not client.atleast_version(*self.minimum_firmware):
             msg = (_('Outdated %s firmware for device labelled %s. Please '
                      'download the updated firmware from %s') %

--- a/plugins/trezor/plugin.py
+++ b/plugins/trezor/plugin.py
@@ -147,7 +147,7 @@ class TrezorCompatiblePlugin(HW_PluginBase):
         return client
 
     def get_coin_name(self):
-        return "Testnet" if TESTNET else "Litecoin"
+        return "Vertcoin Testnet" if TESTNET else "Vertcoin"
 
     def initialize_device(self, device_id, wizard, handler):
         # Initialization method


### PR DESCRIPTION
This fixes a few things (BIP-44 path: vertcoin uses 28, Sign message prefix) and the TREZOR plugin.

Note that TREZOR support needs at the moment a self-compiled firmware for TREZOR with vertcoin support added.

I had to enable the hardware support option.  It may be useful to disable keepkey or ledger support, if they don't work yet.

I only did minimal testing (receiving a coin, sending a transaction with one input, two outputs, no multisig, no segwit).