### PR TITLE
Fix plugin loading on 3.3.0 with new plugin folder name

### DIFF
--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -95,7 +95,7 @@ class Plugins(DaemonThread):
     def load_plugin(self, name):
         if name in self.plugins:
             return self.plugins[name]
-        full_name = 'electrum_plugins.' + name + '.' + self.gui_name
+        full_name = 'electrum_vtc_plugins.' + name + '.' + self.gui_name
         loader = pkgutil.find_loader(full_name)
         if not loader:
             raise RuntimeError("%s implementation for %s plugin not found"


### PR DESCRIPTION
The plugin folder name was updated to "electrum_vtc_plugins" but one of the files was not updated to reflect the change, so I updated it.  Without this fix, 3.3.0-rc1 will fail to load the wallet, and then if you load it yourself, the program will crash and quit, with a traceback reflecting this error.